### PR TITLE
Remove query string from callback url

### DIFF
--- a/lib/omniauth/strategies/flowdock.rb
+++ b/lib/omniauth/strategies/flowdock.rb
@@ -25,6 +25,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('user').parsed
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end


### PR DESCRIPTION
Remove query_string from callback_url to make url match redirect url set while creating developer application in flowdock.